### PR TITLE
Fix processing of server triggered logout events

### DIFF
--- a/StarcorpClient/Assets/Scripts/GameController.cs
+++ b/StarcorpClient/Assets/Scripts/GameController.cs
@@ -63,7 +63,7 @@ public class GameController : MonoBehaviour
         this.socket.Register("player_logout", (ev) =>
         {
             Debug.Log("Processing logout event");
-            string id = (string)ev.Data[0]["id"];
+            string id = (string)ev.Data[0];
 
             Destroy(this.objectManager.Get("player", id));
         });

--- a/StarcorpClient/Assets/Scripts/Login.cs
+++ b/StarcorpClient/Assets/Scripts/Login.cs
@@ -62,9 +62,8 @@ public class Login : MonoBehaviour
 
             this.socket.Register("player_logout", (eve) =>
             {
-                Debug.Log("Checking for client being logged out due to inactivity");
-                string userID = (string)eve.Data[0]
-            ["user_id"];
+                string userID = (string)eve.Data[0];
+                Debug.Log($"Checking for client being logged out due to inactivity: {userID}");
 
                 Debug.Log($"This: {this.socket.userID}, Other: {userID}");
                 if (userID == this.socket.userID)


### PR DESCRIPTION
The client was parsing the "json" data sent when a player logs out improperly.

It no longer should have this problem.