### PR TITLE
Ship attributes

### DIFF
--- a/StarcorpServer/starcorp/data/enums.py
+++ b/StarcorpServer/starcorp/data/enums.py
@@ -40,9 +40,10 @@ class ShipSystemAttributeType(str, Enum):
     COMPONENT_COST = "component_cost"
     BASE_COST = "base_cost"
 
-    SPEED = "speed"
-    POWER = "power"
-    SIZE = "size"
+    MOVEMENT_SPEED = "movement_speed"
+    ATTACK_POWER = "attack_power"
+    GATHER_POWER = "gather_power"
+    CARRY_CAPACITY = "carry_capacity"
 
 
 class UnitType(str, Enum):

--- a/StarcorpServer/starcorp/data/game_data.yaml
+++ b/StarcorpServer/starcorp/data/game_data.yaml
@@ -8,15 +8,15 @@ Sector:
     resources:
       food:
         max_nodes: 4
-        rate: 40
+        rate: 5
         amount_range: 100-500
       water:
         max_nodes: 2
-        rate: 25
+        rate: 8
         amount_range: 500-1000
       fuel:
         max_nodes: 8
-        rate: 10
+        rate: 3
         amount_range: 25-50
 ShipChassis:
   Minnow:
@@ -38,7 +38,7 @@ ShipSystem:
   Scrapper's Cargo Bay Mk 0:
     base_cost: 0.0
     module_cost: 1.0
-    carry_capacity: 30.0
+    carry_capacity: 65.0
 Resources:
   food:
     base_cost: 10

--- a/StarcorpServer/starcorp/data/game_data.yaml
+++ b/StarcorpServer/starcorp/data/game_data.yaml
@@ -29,15 +29,16 @@ ShipSystem:
   Scrapper's Engine Mk 0:
     base_cost: 0.0
     component_cost: 1.0
-    speed: 3.0
+    movement_speed: 3.0
   Scrapper's Laser Mk 0:
     base_cost: 0.0
     hard_point_cost: 1.0
-    power: 3.0
+    attack_power: 3.0
+    gather_power: 5.0
   Scrapper's Cargo Bay Mk 0:
     base_cost: 0.0
     module_cost: 1.0
-    size: 30.0
+    carry_capacity: 30.0
 Resources:
   food:
     base_cost: 10

--- a/StarcorpServer/starcorp/models/ships.py
+++ b/StarcorpServer/starcorp/models/ships.py
@@ -128,6 +128,12 @@ class Ship(Base):
             f"chassis_id={self.chassis_id})"
         )
 
+    @property
+    def resources_held(self):
+        """ Get the total amount of held resources. """
+
+        return sum(slot.amount for slot in self.inventory)
+
     def __getattribute__(self, name):
         try:
             attr = ShipSystemAttributeType(name)

--- a/StarcorpServer/starcorp/server/login.py
+++ b/StarcorpServer/starcorp/server/login.py
@@ -208,8 +208,10 @@ def load_player(message):  # pylint: disable=unused-argument
     ACTIVE_PLAYERS.add(current_user.value)
 
     ship_data = {"id": ship.id, "position": ship.location.coordinate}
-    emit("player_load", ship_data)
     emit("player_joined", ship_data, broadcast=True, include_self=False)
+
+    ship_data["carry_capacity"] = ship.carry_capacity
+    emit("player_load", ship_data)
 
 
 @socketio.on("logout")

--- a/StarcorpServer/starcorp/server/player_input.py
+++ b/StarcorpServer/starcorp/server/player_input.py
@@ -88,6 +88,9 @@ def gather_resource(message):
             "gather_denied",
             {"message": message},
         )
+    elif ship.resources_held >= ship.carry_capacity:
+        LOGGER.debug(f"{ship} unable to gather due to full storage")
+        emit("gather_denied", {"message": "Ship storage full"})
     else:
         resource = resource_node.resource
 


### PR DESCRIPTION
closes #45 

This PR adds the ability to dynamically load attributes from a ship model. 

The query traces down through all the related tables to aggregate the total amount of a particular stat that all the ship's installed modules provide.

The only attributes currently in use are `gather_power` and `carry_capacity`